### PR TITLE
Standardize and clean username format on verify

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -50,6 +50,7 @@ bot.on("message", async (msg) => {
 					);
 					break;
 				}
+				args[0] = args[0].toLowerCase().replace(/[^a-z0-9.]/g, "");
 				if (functions.isUsernameTaken(args[0], msg)) {
 					msg.channel.send(
 						`That username is already associated with a verified account!` +


### PR DESCRIPTION
The check to see if a username is taken upon verify can be easily bypassed, either by capitalizing characters (uSername instead of username) or by throwing in random special characters.

Waterloo's API seems to ignore certain special characters, so a request for "username*+" would return the same result as "username", and the bot treats them as different usernames. By converting the username to lowercase and removing characters outside of the range of a-z, 0-9 or a period, this issue can be fixed.